### PR TITLE
Separate reducers and rename productsActions to productActions

### DIFF
--- a/client/src/actions/customerActions.jsx
+++ b/client/src/actions/customerActions.jsx
@@ -1,28 +1,7 @@
 import axios from 'axios';
 
-export const FETCH_PRODUCTS_SUCCESS = 'FETCH_PRODUCTS_SUCCESS';
-export const FETCH_PRODUCTS_FAILURE = 'FETCH_PRODUCTS_FAILURE';
 export const FETCH_CUSTOMER_SUCCESS = 'FETCH_CUSTOMER_SUCCESS';
 export const FETCH_CUSTOMER_FAILURE = 'FETCH_CUSTOMER_FAILURE';
-
-export const fetchProducts = (url = '/api/products') => (dispatch) => {
-  dispatch(fetchProductsLoading(true));
-  axios.get(url)
-    .then(res => dispatch({
-      type: FETCH_PRODUCTS_SUCCESS,
-      items: res.data,
-    }))
-    .catch(err => dispatch({
-      type: FETCH_PRODUCTS_FAILURE,
-      error: err,
-    }));
-};
-
-export const fetchProductsLoading = bool => ({
-  type: 'PRODUCTS_LOADING',
-  isLoading: bool,
-});
-
 
 export const fetchCustomerLoading = bool => ({
   type: 'CUSTOMER_LOADING',

--- a/client/src/actions/productActions.jsx
+++ b/client/src/actions/productActions.jsx
@@ -4,6 +4,8 @@ export const ADD_PRODUCT_SUCCESS = 'ADD_PRODUCT_SUCCESS';
 export const ADD_PRODUCT_FAILURE = 'ADD_PRODUCT_FAILURE';
 export const DELETE_PRODUCT_SUCCESS = 'DELETE_PRODUCT_SUCCESS';
 export const DELETE_PRODUCT_FAILURE = 'DELETE_PRODUCT_FAILURE';
+export const FETCH_PRODUCTS_SUCCESS = 'FETCH_PRODUCTS_SUCCESS';
+export const FETCH_PRODUCTS_FAILURE = 'FETCH_PRODUCTS_FAILURE';
 
 export const addProduct = product => (dispatch) => {
   axios.post('/api/products', product)
@@ -28,3 +30,22 @@ export const deleteProduct = product => (dispatch) => {
       error: err,
     }));
 };
+
+export const fetchProducts = (url = '/api/products') => (dispatch) => {
+  dispatch(fetchProductsLoading(true));
+  axios.get(url)
+    .then(res => dispatch({
+      type: FETCH_PRODUCTS_SUCCESS,
+      items: res.data,
+    }))
+    .catch(err => dispatch({
+      type: FETCH_PRODUCTS_FAILURE,
+      error: err,
+    }));
+};
+
+export const fetchProductsLoading = bool => ({
+  type: 'PRODUCTS_LOADING',
+  isLoading: bool,
+});
+

--- a/client/src/containers/BroadcastView.jsx
+++ b/client/src/containers/BroadcastView.jsx
@@ -5,7 +5,7 @@ import { Auth } from '../Auth/Auth.js';
 const auth = new Auth();
 
 import { connect } from 'react-redux';
-import { fetchProducts } from '../actions/actions.jsx';
+import { fetchProducts } from '../actions/productActions.jsx';
 import { changeVideo, changeBroadcastMessage, selectFeaturedProduct } from '../actions/broadcastActions.jsx';
 
 import BroadcastViewVideo from '../components/broadcast/BroadcastViewVideo.jsx';

--- a/client/src/containers/CustomerHome.jsx
+++ b/client/src/containers/CustomerHome.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { Auth } from '../Auth/Auth';
-import { fetchCustomerInfo } from '../actions/actions.jsx';
+import { fetchCustomerInfo } from '../actions/customerActions.jsx';
 import CustomerProfile from '../components/customer/CustomerProfile.jsx';
 
 const auth = new Auth();

--- a/client/src/containers/ProductsView.jsx
+++ b/client/src/containers/ProductsView.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import AddProductForm from '../components/products/AddProductForm.jsx';
 import ProductList from '../components/products/ProductList.jsx';
 import { connect } from 'react-redux';
-import { addProduct, deleteProduct } from '../actions/productsActions.jsx';
-import { fetchProducts } from '../actions/actions.jsx';
+import { addProduct, deleteProduct, fetchProducts } from '../actions/productActions.jsx';
 import { Redirect } from 'react-router';
 import { Auth } from '../Auth/Auth.js';
 

--- a/client/src/containers/StoreView.jsx
+++ b/client/src/containers/StoreView.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import StoreItem from '../components/customer/StoreItem.jsx';
 import { connect } from 'react-redux';
-import { fetchProducts } from '../actions/actions.jsx';
+import { fetchProducts } from '../actions/productActions.jsx';
 
 class StoreView extends React.Component {
   constructor(props) {

--- a/client/src/reducers/broadcastReducers.jsx
+++ b/client/src/reducers/broadcastReducers.jsx
@@ -1,0 +1,40 @@
+import {
+  CHANGE_VIDEO,
+  CHANGE_BROADCAST_MESSAGE,
+  SELECT_FEATURED_PRODUCT,
+} from '../actions/broadcastActions.jsx';
+
+export function broadcastMessage(state = '', action) {
+  switch (action.type) {
+    case CHANGE_BROADCAST_MESSAGE: {
+      return action.broadcastMessage;
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
+export function featuredProduct(state = false, action) {
+  switch (action.type) {
+    case SELECT_FEATURED_PRODUCT: {
+      console.log(action.product);
+      return action.product;
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
+export function video(state = '', action) {
+  switch (action.type) {
+    case CHANGE_VIDEO: {
+      return action.video;
+    }
+    default: {
+      return state;
+    }
+  }
+}
+

--- a/client/src/reducers/customerReducers.jsx
+++ b/client/src/reducers/customerReducers.jsx
@@ -1,0 +1,19 @@
+import {
+  FETCH_CUSTOMER_SUCCESS,
+  FETCH_CUSTOMER_FAILURE,
+} from '../actions/customerActions.jsx';
+
+export function customerInfo(state = {}, action) {
+  switch (action.type) {
+    case FETCH_CUSTOMER_SUCCESS: {
+      return action.customerInfo;
+    }
+    case FETCH_CUSTOMER_FAILURE: {
+      console.error(action.error);
+      return state;
+    }
+    default: {
+      return state;
+    }
+  }
+}

--- a/client/src/reducers/productReducers.jsx
+++ b/client/src/reducers/productReducers.jsx
@@ -1,0 +1,40 @@
+import {
+  ADD_PRODUCT_SUCCESS,
+  ADD_PRODUCT_FAILURE,
+  DELETE_PRODUCT_SUCCESS,
+  DELETE_PRODUCT_FAILURE,
+  FETCH_PRODUCTS_SUCCESS,
+  FETCH_PRODUCTS_FAILURE,
+} from '../actions/productActions.jsx';
+
+export function items(state = [], action) {
+  switch (action.type) {
+    case ADD_PRODUCT_SUCCESS: {
+      return [...state, action.product];
+    }
+    case ADD_PRODUCT_FAILURE: {
+      console.error(action.error);
+      return state;
+      // notify user of error?
+    }
+    case DELETE_PRODUCT_SUCCESS: {
+      return action.items;
+    }
+    case DELETE_PRODUCT_FAILURE: {
+      console.error(action.error);
+      return state;
+      // notify user of error?
+    }
+    case FETCH_PRODUCTS_SUCCESS: {
+      return action.items;
+    }
+    case FETCH_PRODUCTS_FAILURE: {
+      console.error(action.error);
+      return state;
+      // notify user of error?
+    }
+    default: {
+      return state;
+    }
+  }
+}

--- a/client/src/reducers/reducers.jsx
+++ b/client/src/reducers/reducers.jsx
@@ -1,102 +1,10 @@
 import { combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
-import {
-  ADD_PRODUCT_SUCCESS,
-  ADD_PRODUCT_FAILURE,
-  DELETE_PRODUCT_SUCCESS,
-  DELETE_PRODUCT_FAILURE,
-} from '../actions/productsActions.jsx';
-import {
-  CHANGE_VIDEO,
-  CHANGE_BROADCAST_MESSAGE,
-  SELECT_FEATURED_PRODUCT,
-} from '../actions/broadcastActions.jsx';
-import {
-  FETCH_PRODUCTS_SUCCESS,
-  FETCH_PRODUCTS_FAILURE,
-  FETCH_CUSTOMER_SUCCESS,
-  FETCH_CUSTOMER_FAILURE,
-} from '../actions/actions.jsx';
 
-function items(state = [], action) {
-  switch (action.type) {
-    case ADD_PRODUCT_SUCCESS: {
-      return [...state, action.product];
-    }
-    case ADD_PRODUCT_FAILURE: {
-      console.error(action.error);
-      return state;
-      // notify user of error?
-    }
-    case DELETE_PRODUCT_SUCCESS: {
-      return action.items;
-    }
-    case DELETE_PRODUCT_FAILURE: {
-      console.error(action.error);
-      return state;
-      // notify user of error?
-    }
-    case FETCH_PRODUCTS_SUCCESS: {
-      return action.items;
-    }
-    case FETCH_PRODUCTS_FAILURE: {
-      console.error(action.error);
-      return state;
-      // notify user of error?
-    }
-    default: {
-      return state;
-    }
-  }
-}
-function broadcastMessage(state = '', action) {
-  switch (action.type) {
-    case CHANGE_BROADCAST_MESSAGE: {
-      return action.broadcastMessage;
-    }
-    default: {
-      return state;
-    }
-  }
-}
-
-function video(state = '', action) {
-  switch (action.type) {
-    case CHANGE_VIDEO: {
-      return action.video;
-    }
-    default: {
-      return state;
-    }
-  }
-}
-
-function featuredProduct(state = false, action) {
-  switch (action.type) {
-    case SELECT_FEATURED_PRODUCT: {
-      console.log(action.product);
-      return action.product;
-    }
-    default: {
-      return state;
-    }
-  }
-}
-
-function customerInfo(state = {}, action) {
-  switch (action.type) {
-    case FETCH_CUSTOMER_SUCCESS: {
-      return action.customerInfo;
-    }
-    case FETCH_CUSTOMER_FAILURE: {
-      console.error(action.error);
-      return state;
-    }
-    default: {
-      return state;
-    }
-  }
-}
+//reducers
+import { broadcastMessage, featuredProduct, video } from './broadcastReducers.jsx';
+import { items } from './productReducers.jsx';
+import { customerInfo } from './customerReducers.jsx';
 
 const tradehouseApp = combineReducers({
   items,


### PR DESCRIPTION
Removed general actions folder.
Renamed productsActions.jsx to productActions.jsx based on Brian's previous feedback.
Reducers now in different files based on functionality/feature and imported into main reducers file.